### PR TITLE
Methods to get presigned URLs for GET and POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,48 @@ The method [`storage.deleteObject(container, path)`](https://italypaleale.github
 await storage.deleteObject('testcontainer', 'path/to/file.jpg')
 ````
 
+### storage.presignedGetUrl(container, path, [ttl])
+
+The method [`storage.presignedGetUrl(container, path, [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/core.storageprovider.html#presignedgeturl) returns a Promise that resolves with a pre-signed URL that can be used to download an object using any client (e.g. a web browser).
+
+The `ttl` parameter determines how long the signed URL will be valid for, in seconds from present time.
+
+````js
+// Get the pre-signed URL
+const url = await storage.presignedGetUrl('testcontainer', 'path/to/file.jpg', 60)
+// Result is a full URL, like "https://storage.provider/path?token=..."
+````
+
+The URL can be used to retrieve the object. For example, using curl:
+
+````sh
+curl "https://storage.provider/path?token=..." > /path/to/destination/file
+````
+
+Note that **some providers do not support this method** (Backblaze B2), and will throw an exception every time it's called.
+
+### stor age.presignedPutUrl(container, path, [options], [ttl])
+
+The method [`storage.presignedPutUrl(container, path, [options], [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/core.storageprovider.html#presignedputurl) returns a Promise that resolves with a pre-signed URL that can be used to upload an object to the server, using a PUT request from any client.
+
+The `options` argument can be used by the provider to specify certain requirements for clients that will upload files. For example, it can be used to enforce a certain `Content-Type` header, etc. Its values are the same they are for the `putObject` method. Some providers ignore this value - please refer to the documentation for each provider for more details.
+
+The `ttl` parameter determines how long the signed URL will be valid for, in seconds from present time.
+
+````js
+// Get the pre-signed URL
+const url = await storage.presignedPutUrl('testcontainer', 'path/to/file.jpg', {}, 60)
+// Result is a full URL, like "https://storage.provider/path?token=..."
+````
+
+The URL can be used to upload an object. For example, using curl:
+
+````sh
+curl --request PUT --upload-file "/path/to/file" "https://storage.provider/path?token=..." 
+````
+
+Note that **some providers do not support this method** (Backblaze B2), and will throw an exception every time it's called. Other providers, like Azure Storage, require clients to specify certain options when sending the PUT request; please refer to each provider's documentation.
+
 ### storage.client()
 
 [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/core.storageprovider.html#client) is a getter that exposes the underlying client for the storage provider, allowing for interaction with the provider directly. This is useful for advanced scenarios, such as needing to invoke provider-specific methods that aren't available in SMCloudStore.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4859,16 +4859,16 @@
       "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "randomstring": "^1.1.5",
+    "request": "^2.88.0",
     "tslint": "^5.11.0",
     "typedoc": "^0.12.0",
     "typedoc-plugin-monorepo": "^0.1.0",

--- a/packages/aws-s3/README.md
+++ b/packages/aws-s3/README.md
@@ -59,6 +59,10 @@ With the AWS S3 provider, the [`storage.putObject(container, path, data, [option
   - `'STANDARD_IA'`
   - `'ONEZONE_IA'`
 
+### Using pre-signed URLs
+
+In the method [`storage.presignedPutUrl(container, path, [options], [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/aws_s3.awss3provider.html#presignedputurl), the AWS S3 provider accepts for the `options` argument the same dictionary as the ['`storage.putObject(container, path, data, [options])`'](https://italypaleale.github.io/SMCloudStore/classes/aws_s3.awss3provider.html#putobject) method. If you specify a Content-Type in the request for the presigned URL, for example, clients will need to make PUT requests with the same Content-Type.
+
 ### Accessing the AWS-SDK
 
 The AWS S3 provider is built on top of the official [AWS SDK for JavaScript](https://github.com/aws/aws-sdk-js), which is exposed by calling [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/aws_s3.awss3provider.html#client).

--- a/packages/aws-s3/src/AwsS3Provider.ts
+++ b/packages/aws-s3/src/AwsS3Provider.ts
@@ -4,6 +4,8 @@ import {ListItemObject, ListItemPrefix, ListResults, PutObjectOptions, StoragePr
 import S3 = require('aws-sdk/clients/s3')
 import {Stream} from 'stream'
 
+// Note: when using the AWS SDK, do not use arrow functions as callbacks, as many methods need access to the "this" context the callbacks provide
+
 /**
  * Connection options for an AWS S3 provider.
  */
@@ -68,6 +70,71 @@ function ACLString(access: AwsS3ACL): string {
         default:
             return 'private'
     }
+}
+
+/**
+ * Returns the methodOptions dictionary for the `putObject` S3 method
+ * 
+ * @param options - Dictionary with options
+ * @returns Dictionary to add to methodOptions
+ */
+function PutObjectMethodOptions(options: AwsS3PutObjectOptions): S3.PutObjectRequest {
+    const methodOptions = {} as S3.PutObjectRequest
+
+    // If no other options...
+    if (!options) {
+        return methodOptions
+    }
+
+    // ACL: add only if explicitly passed
+    if (options.access) {
+        methodOptions.ACL = ACLString(options.access)
+    }
+
+    // Storage class
+    if (options.class) {
+        methodOptions.StorageClass = options.class
+    }
+
+    // Enable server-side encryption
+    if (options.serverSideEncryption) {
+        methodOptions.ServerSideEncryption = 'AES256'
+    }
+
+    // Metadata
+    if (options.metadata) {
+        // Clone the metadata object before altering it
+        const metadataClone = Object.assign({}, options.metadata) as {[k: string]: string}
+
+        if (metadataClone['Content-Type']) {
+            methodOptions.ContentType = metadataClone['Content-Type']
+            delete metadataClone['Content-Type']
+        }
+        if (metadataClone['Content-Encoding']) {
+            methodOptions.ContentEncoding = metadataClone['Content-Encoding']
+            delete metadataClone['Content-Encoding']
+        }
+        if (metadataClone['Content-Language']) {
+            methodOptions.ContentLanguage = metadataClone['Content-Language']
+            delete metadataClone['Content-Language']
+        }
+        if (metadataClone['Cache-Control']) {
+            methodOptions.CacheControl = metadataClone['Cache-Control']
+            delete metadataClone['Cache-Control']
+        }
+        if (metadataClone['Content-Disposition']) {
+            methodOptions.ContentDisposition = metadataClone['Content-Disposition']
+            delete metadataClone['Content-Disposition']
+        }
+        if (metadataClone['Content-MD5']) {
+            methodOptions.ContentMD5 = metadataClone['Content-MD5']
+            delete metadataClone['Content-MD5']
+        }
+
+        methodOptions.Metadata = metadataClone
+    }
+
+    return methodOptions
 }
 
 /**
@@ -248,60 +315,16 @@ class AwsS3Provider extends StorageProvider {
         }
 
         return new Promise((resolve, reject) => {
-            // Basic method options
-            const methodOptions = {
-                Body: data,
-                Bucket: container,
-                Key: path
-            } as S3.PutObjectRequest
-
-            // ACL: add only if explicitly passed
-            if (options.access) {
-                methodOptions.ACL = ACLString(options.access)
-            }
-
-            // Storage class
-            if (options.class) {
-                methodOptions.StorageClass = options.class
-            }
-
-            // Enable server-side encryption
-            if (options.serverSideEncryption) {
-                methodOptions.ServerSideEncryption = 'AES256'
-            }
-
-            // Metadata
-            if (options.metadata) {
-                // Clone the metadata object before altering it
-                const metadataClone = Object.assign({}, options.metadata) as {[k: string]: string}
-
-                if (metadataClone['Content-Type']) {
-                    methodOptions.ContentType = metadataClone['Content-Type']
-                    delete metadataClone['Content-Type']
-                }
-                if (metadataClone['Content-Encoding']) {
-                    methodOptions.ContentEncoding = metadataClone['Content-Encoding']
-                    delete metadataClone['Content-Encoding']
-                }
-                if (metadataClone['Content-Language']) {
-                    methodOptions.ContentLanguage = metadataClone['Content-Language']
-                    delete metadataClone['Content-Language']
-                }
-                if (metadataClone['Cache-Control']) {
-                    methodOptions.CacheControl = metadataClone['Cache-Control']
-                    delete metadataClone['Cache-Control']
-                }
-                if (metadataClone['Content-Disposition']) {
-                    methodOptions.ContentDisposition = metadataClone['Content-Disposition']
-                    delete metadataClone['Content-Disposition']
-                }
-                if (metadataClone['Content-MD5']) {
-                    methodOptions.ContentMD5 = metadataClone['Content-MD5']
-                    delete metadataClone['Content-MD5']
-                }
-
-                methodOptions.Metadata = metadataClone
-            }
+            // Build all the methodOptions dictionary
+            const methodOptions = Object.assign(
+                {},
+                {
+                    Body: data,
+                    Bucket: container,
+                    Key: path
+                },
+                PutObjectMethodOptions(options)
+            ) as S3.PutObjectRequest
 
             // Send the request
             this._client.putObject(methodOptions, function(err, response) {
@@ -414,6 +437,71 @@ class AwsS3Provider extends StorageProvider {
                 }
 
                 resolve()
+            })
+        })
+    }
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use to request an object from the server with a GET request, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path of the object, inside the container
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedGetUrl(container: string, path: string, ttl?: number): Promise<string> {
+        return this.presignedUrl('getObject', container, path, ttl)
+    }
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use for PUT operations on an object in the server, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path where to store the object, inside the container
+     * @param options - Key-value pair of options used by providers, including the `metadata` dictionary and additional S3-specific options
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedPutUrl(container: string, path: string, options?: AwsS3PutObjectOptions, ttl?: number): Promise<string> {
+        const additionalMethodOptions = PutObjectMethodOptions(options)
+        return this.presignedUrl('putObject', container, path, additionalMethodOptions, ttl)
+    }
+
+    /**
+     * Returns a presigned URL for the specific S3 operation.
+     * 
+     * @param operation - S3 operation: "getObject" or "putObject"
+     * @param container - Name of the container
+     * @param path - Path of the target object, inside the container
+     * @param additionalMethodOptions - Additional options to pass to the method
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for the specified operation
+     * @async
+     */
+    private presignedUrl(operation: 'getObject'|'putObject', container: string, path: string, additionalMethodOptions: any, ttl?: number): Promise<string> {
+        if (!ttl || ttl < 1) {
+            ttl = 86400
+        }
+
+        const methodOptions = Object.assign(
+            {},
+            {
+                Bucket: container,
+                Expires: ttl,
+                Key: path
+            },
+            additionalMethodOptions
+        )
+
+        return new Promise((resolve, reject) => {
+            this._client.getSignedUrl(operation, methodOptions, function(err, url) {
+                if (err || !url) {
+                    return reject(err || Error('Invalid result when generating the presigned url'))
+                }
+
+                resolve(url)
             })
         })
     }

--- a/packages/aws-s3/src/AwsS3Provider.ts
+++ b/packages/aws-s3/src/AwsS3Provider.ts
@@ -60,11 +60,9 @@ function ACLString(access: AwsS3ACL): string {
         case 'public-read':
         case 'public':
             return 'public-read'
-            break
         case 'public-read-write':
         case 'authenticated-read':
             return access
-            break
         case 'none':
         case 'private':
         default:
@@ -73,7 +71,7 @@ function ACLString(access: AwsS3ACL): string {
 }
 
 /**
- * Returns the methodOptions dictionary for the `putObject` S3 method
+ * Returns the methodOptions dictionary for the `putObject` method
  * 
  * @param options - Dictionary with options
  * @returns Dictionary to add to methodOptions

--- a/packages/azure-storage/README.md
+++ b/packages/azure-storage/README.md
@@ -43,6 +43,28 @@ When using the [`storage.createContainer(container, [options])`](https://italypa
   - `'blob'`
   - `'none'` (alias `'private'` for compatibility with other storage providers)), this is the default value.
 
+### Using pre-signed URLs
+
+In the method [`storage.presignedPutUrl(container, path, [options], [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/azure_storage.azurestorageprovider.html#presignedputurl), the Azure Storage provider accepts for the `options` argument the same dictionary as the ['`storage.putObject(container, path, data, [options])`'](https://italypaleale.github.io/SMCloudStore/classes/azure_storage.azurestorageprovider.html#putobject) method. If you specify a Content-Type in the request for the presigned URL, for example, clients will need to make PUT requests with the same Content-Type.
+
+When uploading an object using a PUT request, Azure Storage requires clients to send an additional header with the request (case-insensitive):
+
+````plain
+X-MS-Blob-Type: BlockBlob
+````
+
+For example, with curl:
+
+````sh
+curl \
+  --request PUT \
+  --upload-file "/path/to/file" \
+  --header 'X-MS-Blob-Type: BlockBlob' \
+  "https://storageaccount.blob.storage.windows.net/path?token=..."
+````
+
+Lastly, please note that Azure Storage supports PUT upload operations with objects no larger than 100 MB. Trying to upload larger objects will fail.
+
 ### Accessing the Azure Storage SDK
 
 The Azure Blob Storage provider is built on top of the official [Azure Storage SDK for Node.js](https://github.com/Azure/azure-storage-node), which is exposed by calling [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/azure_storage.azurestorageprovider.html#client).

--- a/packages/azure-storage/src/AzureStorageProvider.ts
+++ b/packages/azure-storage/src/AzureStorageProvider.ts
@@ -29,6 +29,62 @@ interface AzureStorageCreateContainerOptions {
 }
 
 /**
+ * Returns the request options dictionary for the `putObject` method
+ * 
+ * @param options - Dictionary with options
+ * @returns Dictionary with options to send to Azure
+ */
+function PutObjectRequestOptions(options: PutObjectOptions): Azure.BlobService.CreateBlockBlobRequestOptions {
+    // Azure wants some headers, like Content-Type, outside of the metadata object
+    const requestOptions = {
+        contentSettings: {},
+        metadata: {}
+    } as Azure.BlobService.CreateBlockBlobRequestOptions
+
+    // If no other options...
+    if (!options) {
+        return requestOptions
+    }
+
+    if (options.metadata) {
+        // Clone the metadata object before altering it
+        const metadataClone = Object.assign({}, options.metadata) as {[k: string]: string}
+
+        if (metadataClone['Content-Type']) {
+            requestOptions.contentSettings.contentType = metadataClone['Content-Type']
+            delete metadataClone['Content-Type']
+        }
+        if (metadataClone['Content-Encoding']) {
+            requestOptions.contentSettings.contentEncoding = metadataClone['Content-Encoding']
+            delete metadataClone['Content-Encoding']
+        }
+        if (metadataClone['Content-Language']) {
+            requestOptions.contentSettings.contentLanguage = metadataClone['Content-Language']
+            delete metadataClone['Content-Language']
+        }
+        if (metadataClone['Cache-Control']) {
+            requestOptions.contentSettings.cacheControl = metadataClone['Cache-Control']
+            delete metadataClone['Cache-Control']
+        }
+        if (metadataClone['Content-Disposition']) {
+            requestOptions.contentSettings.contentDisposition = metadataClone['Content-Disposition']
+            delete metadataClone['Content-Disposition']
+        }
+        if (metadataClone['Content-MD5']) {
+            // Content-MD5 is auto-generated if not sent by the user
+            // If sent by the user, then Azure uses it to ensure data did not get altered in transit
+            requestOptions.contentSettings.contentMD5 = metadataClone['Content-MD5']
+            delete metadataClone['Content-MD5']
+        }
+
+        requestOptions.metadata = metadataClone
+    }
+
+
+    return requestOptions
+}
+
+/**
  * Client to interact with Azure Blob Storage.
  */
 class AzureStorageProvider extends StorageProvider {
@@ -192,49 +248,8 @@ class AzureStorageProvider extends StorageProvider {
         if (!data) {
             throw Error('Argument data is empty')
         }
-        if (!options) {
-            options = {}
-        }
 
-        // Azure wants some headers, like Content-Type, outside of the metadata object
-        const requestOptions = {
-            contentSettings: {},
-            metadata: {}
-        } as Azure.BlobService.CreateBlockBlobRequestOptions
-
-        if (options.metadata) {
-            // Clone the metadata object before altering it
-            const metadataClone = Object.assign({}, options.metadata) as {[k: string]: string}
-
-            if (metadataClone['Content-Type']) {
-                requestOptions.contentSettings.contentType = metadataClone['Content-Type']
-                delete metadataClone['Content-Type']
-            }
-            if (metadataClone['Content-Encoding']) {
-                requestOptions.contentSettings.contentEncoding = metadataClone['Content-Encoding']
-                delete metadataClone['Content-Encoding']
-            }
-            if (metadataClone['Content-Language']) {
-                requestOptions.contentSettings.contentLanguage = metadataClone['Content-Language']
-                delete metadataClone['Content-Language']
-            }
-            if (metadataClone['Cache-Control']) {
-                requestOptions.contentSettings.cacheControl = metadataClone['Cache-Control']
-                delete metadataClone['Cache-Control']
-            }
-            if (metadataClone['Content-Disposition']) {
-                requestOptions.contentSettings.contentDisposition = metadataClone['Content-Disposition']
-                delete metadataClone['Content-Disposition']
-            }
-            if (metadataClone['Content-MD5']) {
-                // Content-MD5 is auto-generated if not sent by the user
-                // If sent by the user, then Azure uses it to ensure data did not get altered in transit
-                requestOptions.contentSettings.contentMD5 = metadataClone['Content-MD5']
-                delete metadataClone['Content-MD5']
-            }
-
-            requestOptions.metadata = metadataClone
-        }
+        const requestOptions = PutObjectRequestOptions(options)
 
         return new Promise((resolve, reject) => {
             const callback = (err, response) => {
@@ -393,7 +408,74 @@ class AzureStorageProvider extends StorageProvider {
         })
     }
 
-    /* Internal methods */
+    /**
+     * Returns a URL that clients (e.g. browsers) can use to request an object from the server with a GET request, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path of the object, inside the container
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedGetUrl(container: string, path: string, ttl?: number): Promise<string> {
+        return this.presignedUrl('getObject', container, path, ttl)
+    }
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use for PUT operations on an object in the server, even if the object is private.
+     * 
+     * Notes on using presigned URLs to upload files to Azure Storage using PUT:
+     * 
+     * 1. The maximum file size is 100MB; larger files will trigger an error.
+     * 2. You need to set the `X-MS-Blob-Type: BlockBlob` header for uploads to succeed
+     * 
+     * @param container - Name of the container
+     * @param path - Path where to store the object, inside the container
+     * @param options - Key-value pair of options used by providers, including the `metadata` dictionary and additional S3-specific options
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedPutUrl(container: string, path: string, options?: PutObjectOptions, ttl?: number): Promise<string> {
+        const requestOptions = PutObjectRequestOptions(options)
+        return this.presignedUrl('putObject', container, path, requestOptions.contentSettings, ttl)
+    }
+
+    /**
+     * Returns a presigned URL for the specific S3 operation.
+     * 
+     * @param operation - S3 operation: "getObject" or "putObject"
+     * @param container - Name of the container
+     * @param path - Path of the target object, inside the container
+     * @param contentSettings - Additional headers that are required
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for the specified operation
+     * @async
+     */
+    private presignedUrl(operation: 'getObject'|'putObject', container: string, path: string, contentSettings?: any, ttl?: number): Promise<string> {
+        if (!ttl || ttl < 1) {
+            ttl = 86400
+        }
+
+        // Remove contentMD5 from contentSettings, as that can't be known
+        if (contentSettings && contentSettings.contentMD5) {
+            delete contentSettings.contentMD5
+        }
+
+        // Policy
+        const policy = {
+            AccessPolicy: {
+                Expiry: new Date(Date.now() + ttl * 1000), // Convert TTL to a point in time
+                Permissions: (operation == 'getObject') ? Azure.BlobUtilities.SharedAccessPermissions.READ : Azure.BlobUtilities.SharedAccessPermissions.WRITE
+            }
+        } as Azure.common.SharedAccessPolicy
+
+        const signature = this._client.generateSharedAccessSignature(container, path, policy, contentSettings)
+
+        const url = this._client.getUrl(container, path, signature)
+
+        return Promise.resolve(url)
+    }
 
     /**
      * Create a container on the server, choosing whether to use the "ifNotExists" method or not

--- a/packages/azure-storage/src/AzureStorageProvider.ts
+++ b/packages/azure-storage/src/AzureStorageProvider.ts
@@ -80,7 +80,6 @@ function PutObjectRequestOptions(options: PutObjectOptions): Azure.BlobService.C
         requestOptions.metadata = metadataClone
     }
 
-
     return requestOptions
 }
 
@@ -431,7 +430,7 @@ class AzureStorageProvider extends StorageProvider {
      * 
      * @param container - Name of the container
      * @param path - Path where to store the object, inside the container
-     * @param options - Key-value pair of options used by providers, including the `metadata` dictionary and additional S3-specific options
+     * @param options - Key-value pair of options used by providers, including the `metadata` dictionary
      * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
      * @returns Promise that resolves with the pre-signed URL for GET requests
      * @async
@@ -442,9 +441,9 @@ class AzureStorageProvider extends StorageProvider {
     }
 
     /**
-     * Returns a presigned URL for the specific S3 operation.
+     * Returns a presigned URL for the specific operation.
      * 
-     * @param operation - S3 operation: "getObject" or "putObject"
+     * @param operation - Operation: "getObject" or "putObject"
      * @param container - Name of the container
      * @param path - Path of the target object, inside the container
      * @param contentSettings - Additional headers that are required

--- a/packages/backblaze-b2/README.md
+++ b/packages/backblaze-b2/README.md
@@ -52,6 +52,10 @@ With the Backblaze B2 provider, the [`storage.putObject(container, path, data, [
 
 - `options.length` (optional): as described above, when `data` is a Stream, if the length of the stream can be known in advance, setting `options.length` with the byte size (or the `byteLength` property in the `data` object directly) allows the BackblazeB2 provider to upload the object with a single call. This option is ignored if `data` is a string or Buffer.
 
+### Using pre-signed URLs
+
+Backblaze B2 does not support pre-signed URLs, which are not available in their APIs. Because of that, the methods `presignedGetUrl` and `presignedPutUrl` always throw an exception when called on the BackblazeB2 provider.
+
 ### Accessing the Backblaze B2 library
 
 The AWS S3 provider is built on top of [backblaze-b2](https://github.com/yakovkhalinsky/backblaze-b2), which is exposed by calling [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/backblaze_b2.backblazeb2provider.html#client).

--- a/packages/backblaze-b2/src/B2Upload.ts
+++ b/packages/backblaze-b2/src/B2Upload.ts
@@ -218,6 +218,13 @@ class B2Upload {
         return doUpload()
     }
 
+    /**
+     * Uploads a Readable Stream.
+     * 
+     * @param stream - Readable Stream containing the data to upload
+     * @returns Promise that resolves when the object has been uploaded
+     * @async
+     */
     private putLargeFile(stream?: Readable): Promise<any> {
         // If we are not passed a stream, use this.data
         if (!stream) {
@@ -336,6 +343,15 @@ class B2Upload {
             })
     }
 
+    /**
+     * Uploads a single part of a large file.
+     * 
+     * @param fileId - ID of the large file that is being uploaded
+     * @param partNumber - Number of the part, starting from 1
+     * @param data - Data to upload, in a Buffer
+     * @returns Promise that resolves when the part has been uploaded.
+     * @async
+     */
     private putPart(fileId: string, partNumber: number, data: Buffer): Promise<any> {
         // Backblaze recommends retrying at least two times (up to five) in case of errors, with an incrementing delay. We're retrying all uploads 3 times
         let retryCounter = 0

--- a/packages/backblaze-b2/src/BackblazeB2Provider.ts
+++ b/packages/backblaze-b2/src/BackblazeB2Provider.ts
@@ -328,6 +328,37 @@ class BackblazeB2Provider extends StorageProvider {
     }
 
     /**
+     * Returns a URL that clients (e.g. browsers) can use to request an object from the server with a GET request, even if the object is private.
+     * 
+     * **Backblaze B2 currently does not support this API**, and calling this method will always throw an error. Sorry!
+     * 
+     * @param container - Name of the container
+     * @param path - Path of the object, inside the container
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedGetUrl(container: string, path: string, ttl?: number): Promise<string> {
+        throw Error('Presigned URLs are not supported by the BackblazeB2 Provider')
+    }
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use for PUT operations on an object in the server, even if the object is private.
+     * 
+     * **Backblaze B2 currently does not support this API**, and calling this method will always throw an error. Sorry!
+     * 
+     * @param container - Name of the container
+     * @param path - Path where to store the object, inside the container
+     * @param options - Key-value pair of options used by providers, including the `metadata` dictionary
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedPutUrl(container: string, path: string, options?: PutObjectOptions, ttl?: number): Promise<string> {
+        throw Error('Presigned URLs are not supported by the BackblazeB2 Provider')
+    }
+
+    /**
      * Returns the bucketId property for a given bucket name, as most B2 methods require a bucket's ID.
      * 
      * The result is cached in memory for a certain amount of time configured with `BackblazeB2Provider.bucketIdCacheDuration` (default: 15 minutes), and up to 100 IDs.

--- a/packages/core/src/StorageProvider.ts
+++ b/packages/core/src/StorageProvider.ts
@@ -187,4 +187,27 @@ export abstract class StorageProvider {
      * @async
      */
     abstract deleteObject(container: string, path: string): Promise<void>
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use to request an object from the server with a GET request, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path of the object, inside the container
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    abstract presignedGetUrl(container: string, path: string, ttl?: number): Promise<string>
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use for PUT operations on an object in the server, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path where to store the object, inside the container
+     * @param options - Key-value pair of options used by providers, including the `metadata` dictionary
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    abstract presignedPutUrl(container: string, path: string, options?: PutObjectOptions, ttl?: number): Promise<string>
 }

--- a/packages/generic-s3/README.md
+++ b/packages/generic-s3/README.md
@@ -12,7 +12,7 @@ There are a few provider-specific considerations for the GenericS3 provider.
 
 When initializing the GenericS3 provider, the `connection` argument is an object with:
 
-- `connection.endPoint`: string representing the endpoint of the server to connect to; for AWS S3, this is `s3.amazonaws.com` (this is always required)
+- `connection.endPoint`: string representing the endpoint of the server to connect to; for AWS S3, set this to `s3.amazonaws.com` and the library will pick the correct endpoint based on the `connection.region` argument (default: 'us-east-1')
 - `connection.accessKey`: string containing the access key (the "public key")
 - `connection.secretKey`: string containing the secret key
 - `connection.useSSL` (optional): boolean that will force the connection using HTTPS if true (default: true)

--- a/packages/generic-s3/README.md
+++ b/packages/generic-s3/README.md
@@ -36,6 +36,10 @@ const connection = {
 const storage = SMCloudStore.create('generic-s3', connection)
 ````
 
+### Using pre-signed URLs
+
+In the method [`storage.presignedPutUrl(container, path, [options], [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/generic_s3.generics3provider.html#presignedputurl), the Generic S3 provider ignores the `options` argument, which has no effect on the generated tokens.
+
 ### Accessing the Minio library
 
 The Generic S3 provider is built on top of the [Minio JavaScript client](https://github.com/minio/minio-js), which is exposed by calling [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/generic_s3.generics3provider.html#client).

--- a/packages/generic-s3/src/GenericS3Provider.ts
+++ b/packages/generic-s3/src/GenericS3Provider.ts
@@ -204,11 +204,12 @@ class GenericS3Provider extends StorageProvider {
      * 
      * @param container - Name of the container
      * @param path - Path where to store the object, inside the container
+     * @param options - This argument is ignored by the GenericS3 provider
      * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
      * @returns Promise that resolves with the pre-signed URL for GET requests
      * @async
      */
-    presignedPutUrl(container: string, path: string, ttl?: number): Promise<string> {
+    presignedPutUrl(container: string, path: string, options?: any, ttl?: number): Promise<string> {
         if (!ttl || ttl < 1) {
             ttl = 86400
         }

--- a/packages/generic-s3/src/GenericS3Provider.ts
+++ b/packages/generic-s3/src/GenericS3Provider.ts
@@ -181,6 +181,40 @@ class GenericS3Provider extends StorageProvider {
     deleteObject(container: string, path: string): Promise<void> {
         return this._client.removeObject(container, path)
     }
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use to request an object from the server with a GET request, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path of the object, inside the container
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedGetUrl(container: string, path: string, ttl?: number): Promise<string> {
+        if (!ttl || ttl < 1) {
+            ttl = 86400
+        }
+
+        return this._client.presignedGetObject(container, path, ttl)
+    }
+
+    /**
+     * Returns a URL that clients (e.g. browsers) can use for PUT operations on an object in the server, even if the object is private.
+     * 
+     * @param container - Name of the container
+     * @param path - Path of the object, inside the container
+     * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
+     * @returns Promise that resolves with the pre-signed URL for GET requests
+     * @async
+     */
+    presignedPutUrl(container: string, path: string, ttl?: number): Promise<string> {
+        if (!ttl || ttl < 1) {
+            ttl = 86400
+        }
+
+        return this._client.presignedPutObject(container, path, ttl)
+    }
 }
 
 export = GenericS3Provider

--- a/packages/generic-s3/src/GenericS3Provider.ts
+++ b/packages/generic-s3/src/GenericS3Provider.ts
@@ -203,7 +203,7 @@ class GenericS3Provider extends StorageProvider {
      * Returns a URL that clients (e.g. browsers) can use for PUT operations on an object in the server, even if the object is private.
      * 
      * @param container - Name of the container
-     * @param path - Path of the object, inside the container
+     * @param path - Path where to store the object, inside the container
      * @param ttl - Expiry time of the URL, in seconds (default: 1 day)
      * @returns Promise that resolves with the pre-signed URL for GET requests
      * @async

--- a/packages/google-cloud-storage/README.md
+++ b/packages/google-cloud-storage/README.md
@@ -42,6 +42,14 @@ When using the [`storage.createContainer(container, [options])`](https://italypa
   - `'coldline'`
 - `options.region` (optional): string determining the region in which to create the container; you can see a list in the [official documentation](https://cloud.google.com/storage/docs/bucket-locations). Default value is `us` if storage class is `multi_regional`; `us-central1` otherwise.
 
+### Using pre-signed URLs
+
+In the method [`storage.presignedPutUrl(container, path, [options], [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/azure_storage.azurestorageprovider.html#presignedputurl), the Google Storage provider accepts the following keys for the `options` argument:
+
+- `options.metadata['Content-Type']`: When set, clients uploading objects will have to specify the same "Content-Type" header in the request.
+
+All other values in the `options` dictionary are ignored.
+
 ### Accessing the Google Cloud Storage SDK
 
 The Google Cloud Storage provider is built on top of the official [Google Cloud Storage Node.js client](https://github.com/googleapis/nodejs-storage), which is exposed by calling [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/google_cloud_storage.googlecloudstorageprovider.html#client).

--- a/packages/minio/README.md
+++ b/packages/minio/README.md
@@ -37,6 +37,10 @@ const connection = {
 const storage = SMCloudStore.create('minio', connection)
 ````
 
+### Using pre-signed URLs
+
+In the method [`storage.presignedPutUrl(container, path, [options], [ttl])`](https://italypaleale.github.io/SMCloudStore/classes/minio.minioprovider.html#presignedputurl), the Minio provider ignores the `options` argument, which has no effect on the generated tokens.
+
 ### Accessing the Minio library
 
 The Minio provider is built on top of the [Minio JavaScript client](https://github.com/minio/minio-js), which is exposed by calling [`storage.client()`](https://italypaleale.github.io/SMCloudStore/classes/minio.minioprovider.html#client).

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -6,7 +6,7 @@
 ./node_modules/.bin/tsc -p packages/core/
 
 # Compile all packages
-./node_modules/.bin/tsc -p packages/generic-s3/ # Must be before aws-s3 and minio
+./node_modules/.bin/tsc -p packages/generic-s3/ # Must be before minio
 ./node_modules/.bin/tsc -p packages/aws-s3/
 ./node_modules/.bin/tsc -p packages/azure-storage/
 ./node_modules/.bin/tsc -p packages/backblaze-b2/

--- a/test/AzureStorageProvider.test.js
+++ b/test/AzureStorageProvider.test.js
@@ -6,7 +6,10 @@ const TestSuite = require('./lib/test-suite')
 
 // Execute the test suite
 const testSuiteOptions = {
-    listObjects: ['includeContentType', 'includeContentMD5', 'includeCreationTime']
+    listObjects: ['includeContentType', 'includeContentMD5', 'includeCreationTime'],
+    signedPutRequestHeaders: {
+        'X-MS-Blob-Type': 'BlockBlob'
+    }
 }
 TestSuite('azure-storage', testSuiteOptions)
 

--- a/test/BackblazeB2Provider.test.js
+++ b/test/BackblazeB2Provider.test.js
@@ -16,7 +16,8 @@ const testSuiteOptions = {
     beforeTests: () => {
         // Before all tests, set the chunkSize to 5MB, so we can use smaller files during test
         B2Upload.chunkSize = 5 * 1024 * 1024
-    }
+    },
+    skipPresignedUrlTests: true
 }
 TestSuite('backblaze-b2', testSuiteOptions)
 

--- a/test/data/presigned-files.js
+++ b/test/data/presigned-files.js
@@ -3,8 +3,8 @@
 const presignedFiles = [
     {
         string: 'Si sta come / d\'autunno / sugli alberi / le foglie',
-        destination: 'presigned/ungaretti-soldati.txt',
-        contentType: 'text/plain',
+        destination: 'presigned/ungaretti-soldati',
+        contentType: 'application/x-poem',
         size: 50,
         digestMD5: '31c476243203e9a7a279f3c74881ef79',
         digestSHA1: 'e4f736e1fc24d6081eb6e322efdb1fa4a4b377e1'

--- a/test/data/presigned-files.js
+++ b/test/data/presigned-files.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const presignedFiles = [
+    {
+        string: 'Si sta come / d\'autunno / sugli alberi / le foglie',
+        destination: 'presigned/ungaretti-soldati.txt',
+        contentType: 'text/plain',
+        size: 50,
+        digestMD5: '31c476243203e9a7a279f3c74881ef79',
+        digestSHA1: 'e4f736e1fc24d6081eb6e322efdb1fa4a4b377e1'
+    }
+]
+
+module.exports = presignedFiles

--- a/test/lib/test-suite.js
+++ b/test/lib/test-suite.js
@@ -393,7 +393,7 @@ module.exports = (providerName, testSuiteOptions) => {
                 const headers = Object.assign(
                     {},
                     testSuiteOptions.signedPutRequestHeaders || {},
-                    {'Content-Type': file.contentType,}
+                    {'Content-Type': file.contentType}
                 )
                 const options = {
                     body: file.string,
@@ -481,7 +481,7 @@ module.exports = (providerName, testSuiteOptions) => {
             // If it hasn't happened already, delete all files uploaded, in parallel
             let promises = []
             if (!filesDeleted) {
-                let fileList = testFiles
+                let fileList = [].concat(testFiles, presignedFiles)
                 if (testSuiteOptions && testSuiteOptions.testLargeFiles) {
                     fileList = fileList.concat(largeFiles)
                 }

--- a/test/lib/test-suite.js
+++ b/test/lib/test-suite.js
@@ -390,11 +390,14 @@ module.exports = (providerName, testSuiteOptions) => {
 
             // Try uploading a file via PUT
             await new Promise((resolve, reject) => {
+                const headers = Object.assign(
+                    {},
+                    testSuiteOptions.signedPutRequestHeaders || {},
+                    {'Content-Type': file.contentType,}
+                )
                 const options = {
                     body: file.string,
-                    headers: {
-                        'Content-Type': file.contentType
-                    }
+                    headers: headers
                 }
                 request.put(uploadUrl, options, (error, response, body) => {
                     if (error) {
@@ -403,6 +406,8 @@ module.exports = (providerName, testSuiteOptions) => {
 
                     // Ensure status code is a successful one
                     if (!response || !response.statusCode || response.statusCode < 200 || response.statusCode > 299) {
+                        // eslint-disable-next-line no-console
+                        console.log(response.statusCode, body)
                         return reject(Error('Invalid response status code'))
                     }
                     
@@ -456,7 +461,7 @@ module.exports = (providerName, testSuiteOptions) => {
 
             // Delete all files uploaded, in parallel
             const promises = []
-            let fileList = testFiles.concat(presignedFiles)
+            let fileList = [].concat(testFiles, presignedFiles)
             if (testSuiteOptions && testSuiteOptions.testLargeFiles) {
                 fileList = fileList.concat(largeFiles)
             }

--- a/test/lib/test-suite.js
+++ b/test/lib/test-suite.js
@@ -371,6 +371,14 @@ module.exports = (providerName, testSuiteOptions) => {
         })
 
         it('presignedPutUrl', async function() {
+            // Skip if the provider doesn't support this
+            if (testSuiteOptions.skipPresignedUrlTests) {
+                assert.throws(() => {
+                    storage.presignedGetUrl()
+                })
+                return
+            }
+
             // Increase timeout
             this.timeout(120000)
             this.slow(0)
@@ -417,6 +425,14 @@ module.exports = (providerName, testSuiteOptions) => {
         })
 
         it('presignedGetUrl', async function() {
+            // Skip if the provider doesn't support this
+            if (testSuiteOptions.skipPresignedUrlTests) {
+                assert.throws(() => {
+                    storage.presignedGetUrl()
+                })
+                return
+            }
+
             // Get the pre-signed URL for some files, in parallel
             const promises = []
             for (let i = 0; i < 3; i++) {
@@ -461,7 +477,7 @@ module.exports = (providerName, testSuiteOptions) => {
 
             // Delete all files uploaded, in parallel
             const promises = []
-            let fileList = [].concat(testFiles, presignedFiles)
+            let fileList = [].concat(testFiles, testSuiteOptions.skipPresignedUrlTests ? [] : presignedFiles)
             if (testSuiteOptions && testSuiteOptions.testLargeFiles) {
                 fileList = fileList.concat(largeFiles)
             }
@@ -481,7 +497,7 @@ module.exports = (providerName, testSuiteOptions) => {
             // If it hasn't happened already, delete all files uploaded, in parallel
             let promises = []
             if (!filesDeleted) {
-                let fileList = [].concat(testFiles, presignedFiles)
+                let fileList = [].concat(testFiles, testSuiteOptions.skipPresignedUrlTests ? [] : presignedFiles)
                 if (testSuiteOptions && testSuiteOptions.testLargeFiles) {
                     fileList = fileList.concat(largeFiles)
                 }


### PR DESCRIPTION
Added `storage.presignedGetUrl` and `storage.presignedPutUrl` that return pre-signed URLs that clients (e.g. browsers) can use to interact with the storage provider directly.