### PR TITLE
No longer throw error for the supported B2 provider

### DIFF
--- a/packages/smcloudstore/src/SMCloudStore.ts
+++ b/packages/smcloudstore/src/SMCloudStore.ts
@@ -37,6 +37,7 @@ const SMCloudStore = {
         return [
             'aws-s3',
             'azure-storage',
+            'backblaze-b2',
             'generic-s3',
             'google-cloud-storage',
             'minio'


### PR DESCRIPTION
Adds backblaze B2 to the `providers` list