### PR TITLE
Make GCS Credentials optional

### DIFF
--- a/packages/google-cloud-storage/src/GoogleCloudStorageProvider.ts
+++ b/packages/google-cloud-storage/src/GoogleCloudStorageProvider.ts
@@ -10,9 +10,9 @@ import {Duplex, Stream} from 'stream'
  */
 interface GoogleCloudConnectionOptions {
     /** ID of the Google Cloud project */
-    projectId: string
+    projectId?: string
     /** Path of the JSON file containing the keys */
-    keyFilename: string
+    keyFilename?: string
 }
 
 /**


### PR DESCRIPTION
Google client libraries use the `GOOGLE_APPLICATION_CREDENTIALS` environmental variable by default to load their credentials, so there's no need to provide a path to them in your code.  In fact, in Google Compute Engine, credentials are automatically provided.

It'd be best to make the Typescript types optional.